### PR TITLE
Bump version to 0.0.2 and update package configuration

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -6,9 +6,10 @@ name: Node.js Package
 on:
   push:
     branches: [main]
+    tags: ['v*']
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -1,9 +1,15 @@
 {
   "name": "@arkread/prettier-config",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Prettier config for Ark projects.",
   "main": "index.json",
-  "repository": "@arkread/prettier-config",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/arkread/prettier-config.git"
+  },
+  "files": [
+    "index.json"
+  ],
   "keywords": [
     "prettier",
     "prettier-config"


### PR DESCRIPTION
之前没有在 package.json 声明要 publish 的文件，把 .github 文件也带进去了  
npm registry 和 github package registry 发布的 sha512 不一致  
导致多 registry 构建时依赖安装不上，只能 bump 一下 version 修复

顺便修复 package.json 的 repository 
```
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository.url" was normalized to "git+https://github.com/arkread/prettier-config.git"
```

